### PR TITLE
Fix MTR exec path

### DIFF
--- a/pages/api/lg.ts
+++ b/pages/api/lg.ts
@@ -36,7 +36,7 @@ export default async function handler(
   switch (command) {
     case "mtr":
       args = ["-c", "4", "--report", "--report-wide", payload]
-      cmd = "/usr/bin/mtr";
+      cmd = "/usr/sbin/mtr";
       break;
     case "traceroute":
       args = ["-w2", payload]


### PR DESCRIPTION
MTR was previously called from within `/usr/bin/mtr` however the tool is actually installed at `/usr/sbin/mtr` within the container. This PR fixes the path directory.